### PR TITLE
Fix for Array index out of bounds

### DIFF
--- a/src/main/java/com/darksoldier1404/dppc/builder/command/CommandBuilder.java
+++ b/src/main/java/com/darksoldier1404/dppc/builder/command/CommandBuilder.java
@@ -407,7 +407,8 @@ public class CommandBuilder implements CommandExecutor, TabCompleter {
                 }
                 parsedArgs.put(argDef.index, parsed);
             } catch (NumberFormatException e) {
-                sender.sendMessage(plugin.getPrefix() + "Invalid " + argDef.type.name().toLowerCase() + " for argument '" + argDef.index + "': " + commandArgs[argIndex]);
+                String providedValue = (argIndex >= 0 && argIndex < commandArgs.length) ? commandArgs[argIndex] : "<missing>";
+                sender.sendMessage(plugin.getPrefix() + "Invalid " + argDef.type.name().toLowerCase() + " for argument '" + argDef.index + "': " + providedValue);
                 return true;
             } catch (ArrayIndexOutOfBoundsException e) {
                 // This catch handles cases where commandArgs[argIndex] is accessed but argIndex is out of bounds


### PR DESCRIPTION
General fix approach: never directly index `commandArgs` in error reporting unless bounds are verified at the point of use. In exception paths, use a safe fallback string when the index is invalid.

Best targeted fix (without changing functionality): in `src/main/java/com/darksoldier1404/dppc/builder/command/CommandBuilder.java`, replace the message construction in the `catch (NumberFormatException e)` block so it first computes a safe `providedValue`:
- if `argIndex` is within `[0, commandArgs.length)`, use `commandArgs[argIndex]`
- otherwise use a placeholder like `"<missing>"`

Then use `providedValue` in the message. This preserves existing behavior while removing the out-of-bounds access in the catch block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._