### PR TITLE
Update LuckPerms initialization and implement economy provider abstraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ gradle.properties
 .idea/jarRepositories.xml
 .idea/compiler.xml
 .idea/libraries/
+.idea/copilotDiffState.xml
+.idea/easy-i18n.xml
+.idea/git_toolbox_prj.xml
+.idea/dictionaries/project.xml
 *.iws
 *.iml
 *.ipr

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ sonarqube {
 }
 
 group = 'com.darksoldier1404'
-version = '5.4.1'
+version = '5.4.2'
 def isLatest = false
 def V20 = '1.20.1'
 def V21 = '1.21.11'

--- a/src/main/java/com/darksoldier1404/dppc/api/essentials/MoneyAPI.java
+++ b/src/main/java/com/darksoldier1404/dppc/api/essentials/MoneyAPI.java
@@ -1,99 +1,163 @@
 package com.darksoldier1404.dppc.api.essentials;
 
 import com.darksoldier1404.dppc.DPPCore;
+import com.darksoldier1404.dppc.api.essentials.economy.EconomyProvider;
+import com.darksoldier1404.dppc.api.essentials.economy.EssentialsProvider;
+import com.darksoldier1404.dppc.api.essentials.economy.NullProvider;
+import com.darksoldier1404.dppc.api.essentials.economy.VaultProvider;
+import com.darksoldier1404.dppc.api.logger.DLogManager;
 import com.earth2me.essentials.Essentials;
-import net.ess3.api.MaxMoneyException;
+import net.milkbowl.vault.economy.Economy;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import org.bukkit.plugin.RegisteredServiceProvider;
 
 import java.math.BigDecimal;
 
 @SuppressWarnings("all")
 public class MoneyAPI {
     private final static DPPCore plugin = DPPCore.getInstance();
-    private final static Essentials ess = (Essentials) plugin.ess;
+    private static EconomyProvider provider = new NullProvider();
+
+    /**
+     * Resolves the economy backend based on {@code Settings.economy-provider}.
+     * <p>
+     * Values: {@code AUTO} (EssentialsX first, otherwise Vault), {@code EssentialsX},
+     * {@code Vault}. A forced provider that is unavailable falls back to the other.
+     * Must be called after soft-depend plugins have been initialised.
+     */
+    public static void init() {
+        String setting = "AUTO";
+        if (plugin != null && plugin.config != null) {
+            setting = plugin.config.getString("Settings.economy-provider", "AUTO");
+        }
+
+        EconomyProvider ess = resolveEssentials();
+        EconomyProvider vault = resolveVault();
+
+        if (setting.equalsIgnoreCase("EssentialsX")) {
+            provider = pickForced(ess, vault, "EssentialsX");
+        } else if (setting.equalsIgnoreCase("Vault")) {
+            provider = pickForced(vault, ess, "Vault");
+        } else {
+            if (!setting.equalsIgnoreCase("AUTO")) {
+                warn("Unknown economy-provider '" + setting + "'. Falling back to AUTO.");
+            }
+            provider = (ess != null) ? ess : (vault != null ? vault : new NullProvider());
+        }
+
+        if (provider.isEnabled()) {
+            info("MoneyAPI economy provider: " + provider.getName());
+        } else {
+            warn("No economy provider available. MoneyAPI is disabled.");
+        }
+    }
+
+    private static EconomyProvider pickForced(EconomyProvider preferred, EconomyProvider fallback, String preferredName) {
+        if (preferred != null) {
+            return preferred;
+        }
+        if (fallback != null) {
+            warn(preferredName + " was selected but is not available. Falling back to " + fallback.getName() + ".");
+            return fallback;
+        }
+        warn(preferredName + " was selected but no economy provider is available. MoneyAPI is disabled.");
+        return new NullProvider();
+    }
+
+    private static EconomyProvider resolveEssentials() {
+        if (DPPCore.ess == null) {
+            return null;
+        }
+        return new EssentialsProvider((Essentials) DPPCore.ess);
+    }
+
+    private static EconomyProvider resolveVault() {
+        if (Bukkit.getPluginManager().getPlugin("Vault") == null) {
+            return null;
+        }
+        RegisteredServiceProvider<Economy> rsp = Bukkit.getServicesManager().getRegistration(Economy.class);
+        if (rsp == null) {
+            return null;
+        }
+        Economy econ = rsp.getProvider();
+        if (econ == null) {
+            return null;
+        }
+        return new VaultProvider(econ);
+    }
+
+    private static void info(String message) {
+        if (plugin != null) {
+            plugin.getLog().info(message, DLogManager.printPluginUtilsLogs);
+        }
+    }
+
+    private static void warn(String message) {
+        if (plugin != null) {
+            plugin.getLog().warning(message, DLogManager.printPluginUtilsLogs);
+        }
+    }
 
     public static boolean isEnabled() {
-        return ess != null;
+        return provider.isEnabled();
     }
 
     public static void addMoney(Player p, double amount) {
         if (!isEnabled()) return;
-        try {
-            ess.getUser(p).giveMoney(BigDecimal.valueOf(amount));
-        } catch (MaxMoneyException e) {
-            e.printStackTrace();
-        }
+        provider.add(p, BigDecimal.valueOf(amount));
     }
 
     public static void takeMoney(Player p, double amount) {
         if (!isEnabled()) return;
-        ess.getUser(p).takeMoney(BigDecimal.valueOf(amount));
+        provider.take(p, BigDecimal.valueOf(amount));
     }
 
     public static boolean hasEnoughMoney(Player p, double amount) {
         if (!isEnabled()) return false;
-        return ess.getUser(p).getMoney().doubleValue() >= amount;
+        return provider.has(p, BigDecimal.valueOf(amount));
     }
 
     public static void setMoney(Player p, double amount) {
         if (!isEnabled()) return;
-        try {
-            ess.getUser(p).setMoney(BigDecimal.valueOf(amount));
-        } catch (MaxMoneyException e) {
-            e.printStackTrace();
-        }
+        provider.set(p, BigDecimal.valueOf(amount));
     }
 
     public static void transferMoney(Player p, double amount, Player target) {
         if (!isEnabled()) return;
-        try {
-            ess.getUser(p).takeMoney(BigDecimal.valueOf(amount));
-            ess.getUser(target).giveMoney(BigDecimal.valueOf(amount));
-        } catch (MaxMoneyException e) {
-            e.printStackTrace();
-        }
+        BigDecimal value = BigDecimal.valueOf(amount);
+        provider.take(p, value);
+        provider.add(target, value);
     }
 
     public static void addMoney(Player p, BigDecimal amount) {
         if (!isEnabled()) return;
-        try {
-            ess.getUser(p).giveMoney(amount);
-        } catch (MaxMoneyException e) {
-            e.printStackTrace();
-        }
+        provider.add(p, amount);
     }
 
     public static void takeMoney(Player p, BigDecimal amount) {
         if (!isEnabled()) return;
-        ess.getUser(p).takeMoney(amount);
+        provider.take(p, amount);
     }
 
     public static BigDecimal getMoney(Player p) {
         if (!isEnabled()) return BigDecimal.ZERO;
-        return ess.getUser(p).getMoney();
+        return provider.getMoney(p);
     }
 
     public static boolean hasEnoughMoney(Player p, BigDecimal amount) {
         if (!isEnabled()) return false;
-        return ess.getUser(p).getMoney().compareTo(amount) >= 0;
+        return provider.has(p, amount);
     }
 
     public static void setMoney(Player p, BigDecimal amount) {
         if (!isEnabled()) return;
-        try {
-            ess.getUser(p).setMoney(amount);
-        } catch (MaxMoneyException e) {
-            e.printStackTrace();
-        }
+        provider.set(p, amount);
     }
 
     public static void transferMoney(Player p, BigDecimal amount, Player target) {
         if (!isEnabled()) return;
-        try {
-            ess.getUser(p).takeMoney(amount);
-            ess.getUser(target).giveMoney(amount);
-        } catch (MaxMoneyException e) {
-            e.printStackTrace();
-        }
+        provider.take(p, amount);
+        provider.add(target, amount);
     }
 }

--- a/src/main/java/com/darksoldier1404/dppc/api/essentials/economy/EconomyProvider.java
+++ b/src/main/java/com/darksoldier1404/dppc/api/essentials/economy/EconomyProvider.java
@@ -1,0 +1,34 @@
+package com.darksoldier1404.dppc.api.essentials.economy;
+
+import org.bukkit.entity.Player;
+
+import java.math.BigDecimal;
+
+/**
+ * Backend abstraction used by {@link com.darksoldier1404.dppc.api.essentials.MoneyAPI}.
+ * <p>
+ * Implementations wrap a concrete economy backend (EssentialsX, Vault, ...) so that
+ * MoneyAPI's public methods can stay unchanged while the underlying provider varies.
+ */
+public interface EconomyProvider {
+
+    /**
+     * @return human readable backend name (e.g. {@code "EssentialsX"}, {@code "Vault"}).
+     */
+    String getName();
+
+    /**
+     * @return {@code true} if this provider is usable.
+     */
+    boolean isEnabled();
+
+    BigDecimal getMoney(Player p);
+
+    boolean has(Player p, BigDecimal amount);
+
+    void add(Player p, BigDecimal amount);
+
+    void take(Player p, BigDecimal amount);
+
+    void set(Player p, BigDecimal amount);
+}

--- a/src/main/java/com/darksoldier1404/dppc/api/essentials/economy/EssentialsProvider.java
+++ b/src/main/java/com/darksoldier1404/dppc/api/essentials/economy/EssentialsProvider.java
@@ -1,0 +1,62 @@
+package com.darksoldier1404.dppc.api.essentials.economy;
+
+import com.earth2me.essentials.Essentials;
+import net.ess3.api.MaxMoneyException;
+import org.bukkit.entity.Player;
+
+import java.math.BigDecimal;
+
+/**
+ * EssentialsX backed economy provider. Uses {@link BigDecimal} natively, so no
+ * precision is lost compared to the original MoneyAPI implementation.
+ */
+public class EssentialsProvider implements EconomyProvider {
+    private final Essentials ess;
+
+    public EssentialsProvider(Essentials ess) {
+        this.ess = ess;
+    }
+
+    @Override
+    public String getName() {
+        return "Essentials";
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return ess != null;
+    }
+
+    @Override
+    public BigDecimal getMoney(Player p) {
+        return ess.getUser(p).getMoney();
+    }
+
+    @Override
+    public boolean has(Player p, BigDecimal amount) {
+        return ess.getUser(p).getMoney().compareTo(amount) >= 0;
+    }
+
+    @Override
+    public void add(Player p, BigDecimal amount) {
+        try {
+            ess.getUser(p).giveMoney(amount);
+        } catch (MaxMoneyException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void take(Player p, BigDecimal amount) {
+        ess.getUser(p).takeMoney(amount);
+    }
+
+    @Override
+    public void set(Player p, BigDecimal amount) {
+        try {
+            ess.getUser(p).setMoney(amount);
+        } catch (MaxMoneyException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/darksoldier1404/dppc/api/essentials/economy/NullProvider.java
+++ b/src/main/java/com/darksoldier1404/dppc/api/essentials/economy/NullProvider.java
@@ -1,0 +1,44 @@
+package com.darksoldier1404.dppc.api.essentials.economy;
+
+import org.bukkit.entity.Player;
+
+import java.math.BigDecimal;
+
+/**
+ * No-op provider used when no economy backend is available. Mirrors the original
+ * MoneyAPI behaviour of silently doing nothing when Essentials was missing.
+ */
+public class NullProvider implements EconomyProvider {
+
+    @Override
+    public String getName() {
+        return "None";
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+
+    @Override
+    public BigDecimal getMoney(Player p) {
+        return BigDecimal.ZERO;
+    }
+
+    @Override
+    public boolean has(Player p, BigDecimal amount) {
+        return false;
+    }
+
+    @Override
+    public void add(Player p, BigDecimal amount) {
+    }
+
+    @Override
+    public void take(Player p, BigDecimal amount) {
+    }
+
+    @Override
+    public void set(Player p, BigDecimal amount) {
+    }
+}

--- a/src/main/java/com/darksoldier1404/dppc/api/essentials/economy/VaultProvider.java
+++ b/src/main/java/com/darksoldier1404/dppc/api/essentials/economy/VaultProvider.java
@@ -1,0 +1,64 @@
+package com.darksoldier1404.dppc.api.essentials.economy;
+
+import net.milkbowl.vault.economy.Economy;
+import org.bukkit.entity.Player;
+
+import java.math.BigDecimal;
+
+/**
+ * Vault backed economy provider. Works with any economy plugin that registers a
+ * Vault {@link Economy} service (EssentialsX, CMI, ...).
+ * <p>
+ * Note: Vault's API is {@code double} based, so values are converted from
+ * {@link BigDecimal}; very large or high precision amounts may lose precision.
+ * Vault has no native {@code setMoney}, so {@link #set} is emulated by depositing
+ * or withdrawing the difference from the current balance.
+ */
+public class VaultProvider implements EconomyProvider {
+    private final Economy econ;
+
+    public VaultProvider(Economy econ) {
+        this.econ = econ;
+    }
+
+    @Override
+    public String getName() {
+        return "Vault";
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return econ != null && econ.isEnabled();
+    }
+
+    @Override
+    public BigDecimal getMoney(Player p) {
+        return BigDecimal.valueOf(econ.getBalance(p));
+    }
+
+    @Override
+    public boolean has(Player p, BigDecimal amount) {
+        return econ.has(p, amount.doubleValue());
+    }
+
+    @Override
+    public void add(Player p, BigDecimal amount) {
+        econ.depositPlayer(p, amount.doubleValue());
+    }
+
+    @Override
+    public void take(Player p, BigDecimal amount) {
+        econ.withdrawPlayer(p, amount.doubleValue());
+    }
+
+    @Override
+    public void set(Player p, BigDecimal amount) {
+        double current = econ.getBalance(p);
+        double target = amount.doubleValue();
+        if (target > current) {
+            econ.depositPlayer(p, target - current);
+        } else if (target < current) {
+            econ.withdrawPlayer(p, current - target);
+        }
+    }
+}

--- a/src/main/java/com/darksoldier1404/dppc/api/luckperms/LuckpermAPI.java
+++ b/src/main/java/com/darksoldier1404/dppc/api/luckperms/LuckpermAPI.java
@@ -3,6 +3,7 @@ package com.darksoldier1404.dppc.api.luckperms;
 import com.darksoldier1404.dppc.DPPCore;
 import com.darksoldier1404.dppc.api.logger.DLogNode;
 import net.luckperms.api.LuckPerms;
+import net.luckperms.api.LuckPermsProvider;
 import net.luckperms.api.model.user.User;
 import net.luckperms.api.node.Node;
 import net.luckperms.api.node.types.PrefixNode;
@@ -18,7 +19,7 @@ import java.util.logging.Logger;
 
 public class LuckpermAPI {
     private static final DPPCore plugin = DPPCore.getInstance();
-    private static final LuckPerms lp = (LuckPerms) DPPCore.lp;
+    private static final LuckPerms lp = LuckPermsProvider.get();
     private static final String PREFIX = "[DPP-Core.LuckpermAPI] ";
     private static final String MSG_USER_NOT_FOUND = PREFIX + "User not found.";
     private static final @NotNull DLogNode logger = plugin.getLog();

--- a/src/main/java/com/darksoldier1404/dppc/api/luckperms/PermissionAPI.java
+++ b/src/main/java/com/darksoldier1404/dppc/api/luckperms/PermissionAPI.java
@@ -2,6 +2,7 @@ package com.darksoldier1404.dppc.api.luckperms;
 
 import com.darksoldier1404.dppc.DPPCore;
 import net.luckperms.api.LuckPerms;
+import net.luckperms.api.LuckPermsProvider;
 import net.luckperms.api.model.user.User;
 import net.luckperms.api.node.Node;
 import org.bukkit.Bukkit;
@@ -13,7 +14,7 @@ import java.util.UUID;
 
 public class PermissionAPI {
     private final static DPPCore plugin = DPPCore.getInstance();
-    private static final LuckPerms lp = (LuckPerms) DPPCore.lp;
+    private static final LuckPerms lp = LuckPermsProvider.get();
     private static final String prefix = "[DPP-Core.PermissionAPI] ";
 
     public static boolean isPlayerInGroup(Player player, String group) {

--- a/src/main/java/com/darksoldier1404/dppc/utils/PluginUtil.java
+++ b/src/main/java/com/darksoldier1404/dppc/utils/PluginUtil.java
@@ -1,6 +1,7 @@
 package com.darksoldier1404.dppc.utils;
 
 import com.darksoldier1404.dppc.DPPCore;
+import com.darksoldier1404.dppc.api.essentials.MoneyAPI;
 import com.darksoldier1404.dppc.api.logger.DLogManager;
 import com.darksoldier1404.dppc.api.placeholder.PlaceholderBuilder;
 import com.darksoldier1404.dppc.builder.action.ActionBuilder;
@@ -103,6 +104,10 @@ public class PluginUtil {
         DPPCore.lp = getPluginInstance("LuckPerms", "PermissionAPI", DependPlugin.LuckPerms);
         getPluginInstance("WorldGuard", "WorldGuardAPI", DependPlugin.WorldGuard);
         getPluginInstance("PlaceholderAPI", "PlaceholderUtils", DependPlugin.PlaceholderAPI);
+        if (getServer().getPluginManager().getPlugin("Vault") != null) {
+            dependPlugins.add(DependPlugin.Vault);
+        }
+        MoneyAPI.init();
     }
 
     public static boolean isDependPluginLoaded(DependPlugin dependPlugin) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -4,6 +4,12 @@ Settings:
 
   prefix: "&f[ &bDPP-Core &f] "
 
+  # Economy backend used by MoneyAPI for all DP-Plugins.
+  # AUTO        - Use EssentialsX if installed, otherwise fall back to Vault.
+  # EssentialsX - Force EssentialsX (falls back to Vault if not installed).
+  # Vault       - Force Vault (falls back to EssentialsX if not installed).
+  economy-provider: AUTO
+
   Log: # Settings for DP-Plugins logging system.
     save_period: 3600  # Time in seconds to save the log file.
     save_integrated: true  # If true, integrated logs will be saved in a single file.

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: DPP-Core
-version: 5.4.1
+version: 5.4.2
 description: All DP-PLUGINS plugins require this plugin.
 main: com.darksoldier1404.dppc.DPPCore
 authors: [ DEAD_POOLIO_ ]


### PR DESCRIPTION
This pull request introduces a major refactor and improvement to the `MoneyAPI`, allowing it to support multiple economy backends (EssentialsX and Vault) via a new abstraction layer. The system now auto-detects or can be configured to use a specific provider, improving flexibility and plugin compatibility. Additionally, LuckPerms integration is updated for better reliability, and configuration options are expanded.

**Economy System Refactor and Backend Abstraction**

* Refactored `MoneyAPI` to use a new `EconomyProvider` interface, allowing pluggable economy backends and improved error handling. The API now supports EssentialsX, Vault, or a fallback no-op provider, with backend selection controlled via the new `economy-provider` config option. (`MoneyAPI.java`, `EconomyProvider.java`, `EssentialsProvider.java`, `VaultProvider.java`, `NullProvider.java`) [[1]](diffhunk://#diff-fb7e1d02ccbe5fa15083940eae61a314229a0a5ca4ee73c6f1ad500c69a0f1bdR4-R161) [[2]](diffhunk://#diff-6354528e2299f36c4e547253eb7d19439124775eb8f070fec9da7e2c5b857e76R1-R34) [[3]](diffhunk://#diff-e88d89d84a2eca4a3f887c20eb30b26d08e32fc857996b9528f2409b21801f38R1-R62) [[4]](diffhunk://#diff-6647c393af82e535a9b13840f3f6dcf9de29d26389c88448ba5c46ed33388780R1-R64) [[5]](diffhunk://#diff-af829a917f8ccd6515ff484df5f587574bb0e04c649369dc6e9f78b044ff8a1eR1-R44)
* Added initialization logic in `PluginUtil.initializeSoftDependPlugins()` to detect Vault and initialize the MoneyAPI after soft dependencies are loaded. (`PluginUtil.java`) [[1]](diffhunk://#diff-385c68a22a8ed149ccb6bf84f4149b25e66ad2fa148731778cd070310fe07f49R4) [[2]](diffhunk://#diff-385c68a22a8ed149ccb6bf84f4149b25e66ad2fa148731778cd070310fe07f49R107-R110)
* Updated `config.yml` to introduce the `economy-provider` setting, allowing users to control which backend is used (`AUTO`, `EssentialsX`, or `Vault`). (`config.yml`)

**LuckPerms Integration Improvements**

* Updated LuckPerms API usage to use `LuckPermsProvider.get()` directly, improving reliability and removing dependency on manual plugin instance assignment. (`LuckpermAPI.java`, `PermissionAPI.java`) [[1]](diffhunk://#diff-51b31cac3227c065259f283e32c2719ac0035e0c81d85f832052b5dfb2b069d5R6) [[2]](diffhunk://#diff-51b31cac3227c065259f283e32c2719ac0035e0c81d85f832052b5dfb2b069d5L21-R22) [[3]](diffhunk://#diff-56e477ee3c6663f3efea3ffd0a9e1d801582b61b75906173ac815e49e3134ecfR5) [[4]](diffhunk://#diff-56e477ee3c6663f3efea3ffd0a9e1d801582b61b75906173ac815e49e3134ecfL16-R17)

**Other Changes**

* Bumped plugin version to 5.4.2 in `plugin.yml`.